### PR TITLE
Update meta model structure for labeling

### DIFF
--- a/src/ontology/metamodel/Classifier.js
+++ b/src/ontology/metamodel/Classifier.js
@@ -1,12 +1,9 @@
 export class Classifier {
     constructor (type) {
         this.type = type;
-        this.labels = [];
     }
 
     static fromJson (raw) {
-        const classifier = new Classifier(raw.type);
-        classifier.labels = raw.labels;
-        return classifier;
+        return new Classifier(raw.type);
     }
 }

--- a/src/ontology/metamodel/Relation.js
+++ b/src/ontology/metamodel/Relation.js
@@ -1,7 +1,6 @@
 export class Relation {
     constructor (type) {
         this.type = type;
-        this.labels = [];
         this.arrowStart = null;
         this.arrowEnd = null;
     }
@@ -11,7 +10,6 @@ export class Relation {
         relation.bind = raw.bind;
         relation.arrowStart = raw['arrow-start'];
         relation.arrowEnd = raw['arrow-end'];
-        raw.labels.forEach(label => relation.labels.push(label));
         return relation;
     }
 }

--- a/src/ontology/metamodel/Text.js
+++ b/src/ontology/metamodel/Text.js
@@ -3,6 +3,7 @@ export class Text {
         this.type = type;
         this.default = '';
         this.regex = '.+';
+        this.targets = [];
     }
 
     static fromJson (raw) {
@@ -12,6 +13,9 @@ export class Text {
         }
         if (raw.regex) {
             text.regex = raw.regex;
+        }
+        if (raw.targets) {
+            this.targets = raw.targets;
         }
         return text;
     }


### PR DESCRIPTION
Change labeling syntax to and move to targets array of texts. Classifier and relations does not define their labels anymore. 