### PR TITLE
Restructure labels -> targets in metamodel

### DIFF
--- a/src/ontology/metamodel/Classifier.js
+++ b/src/ontology/metamodel/Classifier.js
@@ -1,12 +1,12 @@
 export class Classifier {
+
     constructor (type) {
         this.type = type;
-        this.labels = [];
     }
 
     static fromJson (raw) {
         const classifier = new Classifier(raw.type);
-        classifier.labels = raw.labels;
         return classifier;
     }
+
 }

--- a/src/ontology/metamodel/Relation.js
+++ b/src/ontology/metamodel/Relation.js
@@ -1,7 +1,7 @@
 export class Relation {
+
     constructor (type) {
         this.type = type;
-        this.labels = [];
         this.arrowStart = null;
         this.arrowEnd = null;
     }
@@ -11,7 +11,7 @@ export class Relation {
         relation.bind = raw.bind;
         relation.arrowStart = raw['arrow-start'];
         relation.arrowEnd = raw['arrow-end'];
-        raw.labels.forEach(label => relation.labels.push(label));
         return relation;
     }
+
 }

--- a/src/ontology/metamodel/Text.js
+++ b/src/ontology/metamodel/Text.js
@@ -1,8 +1,10 @@
 export class Text {
+
     constructor (type) {
         this.type = type;
         this.default = '';
         this.regex = '.+';
+        this.targets = '*';
     }
 
     static fromJson (raw) {
@@ -13,6 +15,10 @@ export class Text {
         if (raw.regex) {
             text.regex = raw.regex;
         }
+        if (raw.targets) {
+            text.targets = raw.targets;
+        }
         return text;
     }
+
 }


### PR DESCRIPTION
Closes #10 

## Changes
- Changed syntax in metamodel, so that texts are defining its targets